### PR TITLE
Update to TLS v1.2 base urls and latest version

### DIFF
--- a/chase/chase.py
+++ b/chase/chase.py
@@ -29,6 +29,11 @@ ENDPOINT_URL_2 = "https://orbital2.chasepaymentech.com/authorize"
 
 CURRENT_DTD_VERSION = "PTI68"
 
+AUTH_PLATFORM_BIN = {
+    'salem': '000001',
+    'pns': '000002'
+}
+
 valid_credit_pattern = re.compile("""
     ^(?:4[0-9]{12}(?:[0-9]{3})?          # Visa
      |  5[1-5][0-9]{14}                  # MasterCard
@@ -98,6 +103,18 @@ class Endpoint(object):
             'Interface-Version':"MooreBro 1.01",
             'MerchantID':str(self.merchant_id),
         }
+        # there are 2 platform options defined in the orbital gateway chase
+        # Salem - BIN 000001
+        # PNS - BIN 000002
+        self.platform = kwargs.pop('platform', 'salem')
+
+    def get_platform_bin(self):
+        try:
+            return AUTH_PLATFORM_BIN[self.platform.lower()]
+
+        except KeyError:
+            raise KeyError('You have supplied an invalid platform identification,'
+                           'you can choose `Salem` (Stratus) or `PNS`')
 
     def make_request(self, xml):
         result = None
@@ -162,6 +179,8 @@ class Endpoint(object):
         root = tree.getroot()
         values['OrbitalConnectionUsername'] = self.username
         values['OrbitalConnectionPassword'] = self.password
+        values['BIN'] = self.get_platform_bin()
+        values['CustomerBin'] = self.get_platform_bin()
         for key,value in values.items():
             elem = root.find(".//%s" % key)
             elem.text = value or default_value

--- a/chase/chase.py
+++ b/chase/chase.py
@@ -183,9 +183,10 @@ class Endpoint(object):
         values['CustomerBin'] = self.get_platform_bin()
         for key,value in values.items():
             elem = root.find(".//%s" % key)
-            elem.text = value or default_value
-            if elem.text != None:
-                elem.text = remove_control_characters(elem.text)
+            if elem:
+                elem.text = value or default_value
+                if elem.text != None:
+                    elem.text = remove_control_characters(elem.text)
         return ET.tostring(root)
 
     def parse_result(self, result):

--- a/chase/chase.py
+++ b/chase/chase.py
@@ -81,9 +81,9 @@ class Endpoint(object):
             trace_number
             production
         """
-        self.merchant_id = kwargs['merchant_id']
-        self.username = kwargs['username']
-        self.password = kwargs['password']
+        self.merchant_id = os.getenv('ORBITAL_MERCHANT_ID') or kwargs.get('merchant_id', '')
+        self.username = os.getenv('ORBITAL_USERNAME') or kwargs.get('username', '')
+        self.password = os.getenv('ORBITAL_PASSWORD') or kwargs.get('password', '')
         self.trace_number = kwargs.get('trace_number', str(uuid4().node))
         self.production = kwargs.get('production', False)
         if self.production:

--- a/chase/chase.py
+++ b/chase/chase.py
@@ -183,7 +183,7 @@ class Endpoint(object):
         values['CustomerBin'] = self.get_platform_bin()
         for key,value in values.items():
             elem = root.find(".//%s" % key)
-            if elem:
+            if elem is not None:
                 elem.text = value or default_value
                 if elem.text != None:
                     elem.text = remove_control_characters(elem.text)

--- a/chase/chase.py
+++ b/chase/chase.py
@@ -22,12 +22,12 @@ CARD_TYPES = [
     CARD_TYPE_JCB,
 ]
 
-TEST_ENDPOINT_URL_1 = "https://orbitalvar1.paymentech.net"
-TEST_ENDPOINT_URL_2 = "https://orbitalvar2.paymentech.net"
-ENDPOINT_URL_1 = "https://orbital1.paymentech.net"
-ENDPOINT_URL_2 = "https://orbital2.paymentech.net"
+TEST_ENDPOINT_URL_1 = "https://orbitalvar1.chasepaymentech.com/authorize"
+TEST_ENDPOINT_URL_2 = "https://orbitalvar2.chasepaymentech.com/authorize"
+ENDPOINT_URL_1 = "https://orbital1.chasepaymentech.com/authorize"
+ENDPOINT_URL_2 = "https://orbital2.chasepaymentech.com/authorize"
 
-CURRENT_DTD_VERSION = "PTI62"
+CURRENT_DTD_VERSION = "PTI68"
 
 valid_credit_pattern = re.compile("""
     ^(?:4[0-9]{12}(?:[0-9]{3})?          # Visa

--- a/chase/mark_for_capture.xml
+++ b/chase/mark_for_capture.xml
@@ -5,7 +5,7 @@
     <OrbitalConnectionPassword></OrbitalConnectionPassword>
     <OrderID></OrderID>
     <Amount></Amount>
-    <BIN>000002</BIN>
+    <BIN></BIN>
     <MerchantID></MerchantID>
     <TerminalID>001</TerminalID>
     <TxRefNum></TxRefNum>

--- a/chase/order_new.xml
+++ b/chase/order_new.xml
@@ -5,7 +5,7 @@
     <OrbitalConnectionPassword></OrbitalConnectionPassword>
     <IndustryType>EC</IndustryType>
     <MessageType>AC</MessageType>
-    <BIN>000002</BIN>
+    <BIN></BIN>
     <MerchantID></MerchantID>
     <TerminalID>001</TerminalID>
     <CardBrand></CardBrand>

--- a/chase/profile_create.xml
+++ b/chase/profile_create.xml
@@ -2,7 +2,7 @@
   <Profile>
     <OrbitalConnectionUsername></OrbitalConnectionUsername>
     <OrbitalConnectionPassword></OrbitalConnectionPassword>
-    <CustomerBin>000002</CustomerBin>
+    <CustomerBin></CustomerBin>
     <CustomerMerchantID></CustomerMerchantID>
     <CustomerName></CustomerName>
     <CustomerRefNum></CustomerRefNum>

--- a/chase/profile_destroy.xml
+++ b/chase/profile_destroy.xml
@@ -2,7 +2,7 @@
   <Profile>
     <OrbitalConnectionUsername></OrbitalConnectionUsername>
     <OrbitalConnectionPassword></OrbitalConnectionPassword>
-    <CustomerBin>000002</CustomerBin>
+    <CustomerBin></CustomerBin>
     <CustomerMerchantID></CustomerMerchantID>
     <CustomerRefNum></CustomerRefNum>
     <CustomerProfileAction>D</CustomerProfileAction>

--- a/chase/profile_read.xml
+++ b/chase/profile_read.xml
@@ -2,7 +2,7 @@
   <Profile>
     <OrbitalConnectionUsername></OrbitalConnectionUsername>
     <OrbitalConnectionPassword></OrbitalConnectionPassword>
-    <CustomerBin>000002</CustomerBin>
+    <CustomerBin></CustomerBin>
     <CustomerMerchantID></CustomerMerchantID>
     <CustomerRefNum></CustomerRefNum>
     <CustomerProfileAction>R</CustomerProfileAction>

--- a/chase/profile_update.xml
+++ b/chase/profile_update.xml
@@ -2,7 +2,7 @@
   <Profile>
     <OrbitalConnectionUsername></OrbitalConnectionUsername>
     <OrbitalConnectionPassword></OrbitalConnectionPassword>
-    <CustomerBin>000002</CustomerBin>
+    <CustomerBin></CustomerBin>
     <CustomerMerchantID></CustomerMerchantID>
     <CustomerName></CustomerName>
     <CustomerRefNum></CustomerRefNum>

--- a/chase/reversal.xml
+++ b/chase/reversal.xml
@@ -7,7 +7,7 @@
     <TxRefIdx></TxRefIdx>
     <AdjustedAmt/>
     <OrderID></OrderID>
-    <BIN>000002</BIN>
+    <BIN></BIN>
     <MerchantID></MerchantID>
     <TerminalID>001</TerminalID>
     <OnlineReversalInd/>

--- a/chase/test_chase.py
+++ b/chase/test_chase.py
@@ -23,17 +23,20 @@ def new_profile():
     profile.cc_expiry = "1116"
     return profile
 
+
 def new_order():
     return Order(merchant_id=merchant_id, 
         username=username,
         password=password
     )
 
+
 def new_reversal():
     return Reversal(merchant_id=merchant_id, 
         username=username,
         password=password
     )
+
 
 class TestProfileFunctions(unittest.TestCase):
 
@@ -96,6 +99,7 @@ class TestProfileFunctions(unittest.TestCase):
         result = profile.destroy()
         self.assertEqual(result['ProfileProcStatus'], '0')
         self.assertEqual(result['CustomerRefNum'], ident)
+
 
 class TestOrderFunctions(unittest.TestCase):
 

--- a/chase/test_chase.py
+++ b/chase/test_chase.py
@@ -1,16 +1,10 @@
-import os
 import unittest
+
 from chase import Profile, Order, Reversal
 
-merchant_id = os.environ.get('TEST_MERCHANT_ID')
-username = os.environ.get('TEST_USERNAME')
-password = os.environ.get('TEST_PASSWORD')
 
 def new_profile():
-    profile = Profile(merchant_id=merchant_id, 
-        username=username,
-        password=password
-    )
+    profile = Profile()
     profile.name = "Test User"
     profile.address1 = "101 Main St."
     profile.address2 = "Apt. 4"
@@ -25,17 +19,11 @@ def new_profile():
 
 
 def new_order():
-    return Order(merchant_id=merchant_id, 
-        username=username,
-        password=password
-    )
+    return Order()
 
 
 def new_reversal():
-    return Reversal(merchant_id=merchant_id, 
-        username=username,
-        password=password
-    )
+    return Reversal()
 
 
 class TestProfileFunctions(unittest.TestCase):
@@ -149,5 +137,3 @@ class TestOrderFunctions(unittest.TestCase):
         result = refund.void()
         self.assertEqual(result['ProcStatus'], '0')
 
-if __name__ == '__main__':
-    unittest.main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,94 +1,55 @@
 """Python Library For Interacting with Chase Paymentech
 """
-
-# Always prefer setuptools over distutils
 from setuptools import setup, find_packages
-# To use a consistent encoding
 from codecs import open
 from os import path
+import sys
 
 here = path.abspath(path.dirname(__file__))
 
-# Get the long description from the relevant file
 with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
+setup_requires = []
+
+if 'test' in sys.argv:
+    setup_requires.append('pytest-runner')
+
+install_requires = [
+    'requests>=2.0',
+]
+
+tests_require = [
+    'pytest',
+    'responses',
+    'coverage >= 3.7.1, < 5.0.0',
+    'pytest-cov',
+]
+
 setup(
     name='chase',
-
-    # Versions should comply with PEP440.  For a discussion on single-sourcing
-    # the version across setup.py and the project code, see
-    # https://packaging.python.org/en/latest/single_source_version.html
     version='1.0.0',
-
     description='Python Library For Chase Paymentech',
     long_description=long_description,
-
-    # The project's main homepage.
     url='https://github.com/dave2328/chase',
-
-    # Author details
     author='James Maxwell',
     author_email='james@dxetech.com',
-
-    # Choose your license
     license='MIT',
-
-    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
-        # How mature is this project? Common values are
-        #   3 - Alpha
-        #   4 - Beta
-        #   5 - Production/Stable
         'Development Status :: 5 - Production/Stable',
-
-        # Indicate who your project is intended for
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Web APIs',
-
-        # Pick your license as you wish (should match "license" above)
         'License :: OSI Approved :: MIT License',
-
-        # Specify the Python versions you support here. In particular, ensure
-        # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
     ],
-
-    # What does your project relate to?
+    packages=find_packages(exclude=['*.tests']),
     keywords='payment',
-
-    # You can just specify the packages manually here if your project is
-    # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-
-    # List run-time dependencies here.  These will be installed by pip when
-    # your project is installed. For an analysis of "install_requires" vs pip's
-    # requirements files see:
-    # https://packaging.python.org/en/latest/requirements.html
-    install_requires=[],
-
-    # List additional groups of dependencies here (e.g. development
-    # dependencies). You can install these using the following syntax,
-    # for example:
-    # $ pip install -e .[dev,test]
+    install_requires=install_requires,
+    tests_require=tests_require,
+    setup_requires=setup_requires,
     extras_require={},
-
-    # If there are data files included in your packages that need to be
-    # installed, specify them here.  If using Python 2.6 or less, then these
-    # have to be included in MANIFEST.in as well.
     package_data={'chase': ['*.xml']},
-
-    # Although 'package_data' is the preferred approach, in some case you may
-    # need to place data files outside of your packages. See:
-    # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
-    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-    data_files=[],
-
-    # To provide executable scripts, use entry points in preference to the
-    # "scripts" keyword. Entry points provide cross-platform support and allow
-    # pip to create the appropriate form of executable for the target platform.
-    entry_points={},
 )
 


### PR DESCRIPTION
Per the latest documentation, you must certify against the TLS v1.2 secured test urls. Also added support for using both authorization platforms.